### PR TITLE
Add GitHub Actions workflow for WordPress.org deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
This workflow will automatically deploy the plugin to WordPress.org when a new tag is pushed to the repository. It requires SVN_USERNAME and SVN_PASSWORD secrets to be configured in the repository settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add GitHub Actions workflow to deploy the plugin to WordPress.org on tag pushes using 10up's deploy action with SVN credentials.
> 
> - **CI/CD**:
>   - Add workflow `/.github/workflows/main.yml` to deploy plugin to WordPress.org on tag pushes.
>   - Uses `10up/action-wordpress-plugin-deploy@stable`; requires `SVN_USERNAME` and `SVN_PASSWORD` secrets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad8566c881ca0db8258d0d2d91398026f5ef408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->